### PR TITLE
generate openapi 3 valid schema and validate it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pydantic>=1.2
+-r requirements/production.txt

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,0 +1,7 @@
+-r production.txt
+openapi-spec-validator==0.2.9
+pytest==6.0.1
+flask==1.1.2
+falcon==2.0.0
+starlette==0.13.7
+requests==2.24.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,0 +1,2 @@
+pydantic>=1.2
+inflection==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     readme = f.read()
 
-with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
+with open(path.join(here, 'requirements/production.txt'), encoding='utf-8') as f:
     requires = [req.strip() for req in f if req]
 
 


### PR DESCRIPTION
This changes the spec generation to be OpenAPI compliant, and adds a test to validate the schema.

# TODO: Confirm that model generation is also fully compliant with standards. 