### PR TITLE
Find all nested references and move them to components/schemas

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,2 +1,3 @@
 pydantic>=1.2
 inflection==0.5.0
+nested-lookup==0.2.21

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -25,6 +25,9 @@ class ExampleNestedList(BaseModel):
 class ExampleNestedModel(BaseModel):
     example: ExampleModel
 
+class ExampleDeepNestedModel(BaseModel):
+    data: List['ExampleModel']
+
 def backend_app():
     return [
         ('flask', Flask(__name__)),
@@ -83,7 +86,9 @@ def create_app():
         pass
 
     @app.route('/lone', methods=['POST'])
-    @api.validate(json=ExampleModel, resp=Response(HTTP_200=ExampleNestedList, HTTP_400=ExampleNestedModel))
+    @api.validate(json=ExampleModel, resp=Response(
+        HTTP_200=ExampleNestedList, HTTP_400=ExampleNestedModel, HTTP_422=ExampleDeepNestedModel
+    ))
     def lone_post():
         pass
 


### PR DESCRIPTION
Finally finds all references to /definitions and reseats them.

Also, bug fix for some properties missing after validation, due to dictionary overwriting.