### PR TITLE
Set validation error code from constructor

### DIFF
--- a/spectree/config.py
+++ b/spectree/config.py
@@ -22,7 +22,7 @@ class Config:
         self._SUPPORT_UI = {'redoc', 'swagger'}
         self.MODE = 'normal'
         self._SUPPORT_MODE = {'normal', 'strict', 'greedy'}
-        self.validation_error_code = 422
+        self.VALIDATION_ERROR_CODE = 422
 
         self.TITLE = 'Service API Document'
         self.VERSION = '0.1'

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 
 from .base import BasePlugin
 from .page import PAGES
+from ..response import DEFAULT_CODE_DESC
 
 
 class OpenAPI:
@@ -157,7 +158,9 @@ class FlaconPlugin(BasePlugin):
 
         except ValidationError as err:
             req_validation_error = err
-            _resp.status = '422 Unprocessable Entity'
+            code = self.config.VALIDATION_ERROR_CODE
+            desc = DEFAULT_CODE_DESC[f'HTTP_{code}']
+            _resp.status = f'{code} {desc}'
             _resp.media = err.errors()
 
         before(_req, _resp, req_validation_error, _self)

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -116,7 +116,7 @@ class FlaskPlugin(BasePlugin):
             self.request_validation(request, query, json, headers, cookies)
         except ValidationError as err:
             req_validation_error = err
-            response = make_response(jsonify(err.errors()), self.config.validation_error_code)
+            response = make_response(jsonify(err.errors()), self.config.VALIDATION_ERROR_CODE)
 
         before(request, response, req_validation_error, None)
         if req_validation_error:

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -64,14 +64,14 @@ class StarlettePlugin(BasePlugin):
             await self.request_validation(request, query, json, headers, cookies)
         except ValidationError as err:
             req_validation_error = err
-            response = JSONResponse(err.errors(), 422)
+            response = JSONResponse(err.errors(), self.config.VALIDATION_ERROR_CODE)
         except JSONDecodeError as err:
             json_decode_error = err
             self.logger.info(
-                '422 Validation Error',
+                f'{self.config.VALIDATION_ERROR_CODE} Validation Error',
                 extra={'spectree_json_decode_error': str(err)}
             )
-            response = JSONResponse({'error_msg': str(err)}, 422)
+            response = JSONResponse({'error_msg': str(err)}, self.config.VALIDATION_ERROR_CODE)
 
         before(request, response, req_validation_error, instance)
         if req_validation_error or json_decode_error:

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -177,7 +177,7 @@ class SpecTree:
                     'description': desc or '',
                     'tags': getattr(func, 'tags', []),
                     'parameters': parse_params(func, parameters[:], self.models),
-                    'responses': parse_resp(func),
+                    'responses': parse_resp(func, self.config.VALIDATION_ERROR_CODE),
                 }
 
                 request_body = parse_request(func)

--- a/spectree/utils.py
+++ b/spectree/utils.py
@@ -79,20 +79,20 @@ def parse_params(func, params, models):
     return params
 
 
-def parse_resp(func):
+def parse_resp(func, code: int):
     """
     get the response spec
 
     If this function does not have explicit ``resp`` but have other models,
-    a ``422 Validation Error`` will be append to the response spec. Since
+    a ``Validation Error`` will be append to the response spec. Since
     this may be triggered in the validation step.
     """
     responses = {}
     if hasattr(func, 'resp'):
         responses = func.resp.generate_spec()
 
-    if '422' not in responses and has_model(func):
-        responses['422'] = {'description': 'Validation Error'}
+    if str(code) not in responses and has_model(func):
+        responses[str(code)] = {'description': 'Validation Error'}
 
     return responses
 
@@ -145,7 +145,7 @@ def default_before_handler(req, resp, req_validation_error, instance):
     """
     if req_validation_error:
         logger.info(
-            '422 Validation Error',
+            'Validation Error',
             extra={
                 'spectree_model': req_validation_error.model.__name__,
                 'spectree_validation': req_validation_error.errors(),

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .common import Query, JSON, Resp, Cookies, Headers, get_paths
+from .common import get_paths
 from .test_plugin_flask import api as flask_api
 from .test_plugin_falcon import api as falcon_api
 from .test_plugin_starlette import api as starlette_api
@@ -8,10 +8,6 @@ from .test_plugin_starlette import api as starlette_api
 
 @pytest.mark.parametrize('api', [flask_api, falcon_api, starlette_api])
 def test_plugin_spec(api):
-    models = {m.__name__: m.schema() for m in (Query, JSON, Resp, Cookies, Headers)}
-    # for name, schema in models.items():
-        # assert api.spec['components']['schemas'][name] == schema  # this is checking it is wrong, not sure how to proceed
-
     assert api.spec['tags'] == [{'name': tag} for tag in ('test', 'health', 'api')]
 
     assert get_paths(api.spec) == ['/api/user/{name}', '/ping']

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -54,7 +54,7 @@ api.register(app)
 
 @pytest.fixture(params=[422, 400])
 def client(request):
-    api.config.validation_error_code = request.param
+    api.config.VALIDATION_ERROR_CODE = request.param
     with app.test_client() as client:
         yield client
 

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -93,6 +93,7 @@ def test_flask_validate(client):
     )
     assert resp.json['score'] == sorted(resp.json['score'], reverse=False)
 
+
 @pytest.mark.parametrize('client', [422], indirect=True)
 def test_flask_doc(client):
     resp = client.get('/apidoc/openapi.json')
@@ -105,6 +106,7 @@ def test_flask_doc(client):
 
     resp = client.get('/apidoc/swagger')
     assert resp.status_code == 200
+
 
 @pytest.mark.parametrize('client', [400], indirect=True)
 def test_flask_validate_with_alternative_code(client):

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -74,7 +74,7 @@ def test_spec_generate(name, app):
     assert spec['tags'] == []
 
 
-api = SpecTree('flask', tags=[{'name': 'lone', 'description': 'a lone api'}])
+api = SpecTree('flask', tags=[{'name': 'lone', 'description': 'a lone api'}], validation_error_code=400)
 api_strict = SpecTree('flask', mode='strict')
 api_greedy = SpecTree('flask', mode='greedy')
 api_customize_backend = SpecTree(backend=FlaskPlugin)
@@ -99,7 +99,7 @@ def create_app():
 
     @app.route('/lone', methods=['POST'])
     @api.validate(json=ExampleModel, resp=Response(
-        HTTP_200=ExampleNestedList, HTTP_400=ExampleNestedModel, HTTP_422=ExampleDeepNestedModel
+        HTTP_200=ExampleNestedList, HTTP_400=ExampleNestedModel
     ), tags=['lone'])
     def lone_post():
         pass

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -74,7 +74,11 @@ def test_spec_generate(name, app):
     assert spec['tags'] == []
 
 
-api = SpecTree('flask', tags=[{'name': 'lone', 'description': 'a lone api'}], validation_error_code=400)
+api = SpecTree(
+    'flask',
+    tags=[{'name': 'lone', 'description': 'a lone api'}],
+    validation_error_code=400,
+)
 api_strict = SpecTree('flask', mode='strict')
 api_greedy = SpecTree('flask', mode='greedy')
 api_customize_backend = SpecTree(backend=FlaskPlugin)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -71,16 +71,21 @@ def test_has_model():
 
 
 def test_parse_resp():
-    assert parse_resp(undecorated_func) == {}
-    assert parse_resp(demo_class.demo_method) == {
+    assert parse_resp(undecorated_func, 422) == {}
+    assert parse_resp(demo_class.demo_method, 422) == {
         '422': {
             'description': 'Validation Error'
         }
     }
-    resp_spec = parse_resp(demo_func)
+    resp_spec = parse_resp(demo_func, 422)
     assert resp_spec['422']['description'] == 'Validation Error'
     assert resp_spec['200']['content']['application/json']['schema']['$ref'] \
         == '#/components/schemas/DemoModel'
+
+    resp_spec = parse_resp(demo_func, 400)
+    assert '422' not in resp_spec
+    assert resp_spec['400']['description'] == 'Validation Error'
+
 
 
 def test_parse_request():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,7 +87,6 @@ def test_parse_resp():
     assert resp_spec['400']['description'] == 'Validation Error'
 
 
-
 def test_parse_request():
     assert parse_request(demo_func)['content']['application/json']['schema']['$ref'] \
         == '#/components/schemas/DemoModel'


### PR DESCRIPTION
Allows the validation error code config option to be set from the
SpecTree constructor.