### PR TITLE
Add FileResponse class

### DIFF
--- a/spectree/response.py
+++ b/spectree/response.py
@@ -76,6 +76,39 @@ class Response:
         return responses
 
 
+class FileResponse:
+
+    def __init__(self, content_type: str = "application/octet-stream"):
+        self.content_type = content_type
+        self.models = []  # cannot provide models to a File response
+
+    def has_model(self):
+        """
+        File response cannot have a model
+        """
+        return False
+
+    def generate_spec(self):
+        responses = {
+            "200": {
+                'description': DEFAULT_CODE_DESC["HTTP_200"],
+                'content': {
+                    self.content_type: {
+                        'schema': {
+                            "type": "string",
+                            "format": "binary"
+                        }
+                    }
+                }
+            },
+            "404": {
+                'description': DEFAULT_CODE_DESC["HTTP_404"]
+            }
+        }
+
+        return responses
+
+
 # according to https://tools.ietf.org/html/rfc2616#section-10
 # https://tools.ietf.org/html/rfc7231#section-6.1
 # https://developer.mozilla.org/sv-SE/docs/Web/HTTP/Status

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,6 +1,6 @@
 import pytest
 
-from spectree.response import Response, DEFAULT_CODE_DESC
+from spectree.response import Response, DEFAULT_CODE_DESC, FileResponse
 
 from .common import DemoModel
 
@@ -42,3 +42,21 @@ def test_response_spec():
 
     assert spec.get(200) is None
     assert spec.get(404) is None
+
+
+def test_file_response_spec():
+    octet_resp = FileResponse()
+    spec = octet_resp.generate_spec()
+    assert spec['200']['description'] == DEFAULT_CODE_DESC["HTTP_200"]
+    assert spec['404']['description'] == DEFAULT_CODE_DESC["HTTP_404"]
+
+    assert spec['200']['content']['application/octet-stream']['schema']['format'] == 'binary'
+    assert spec['200']['content']['application/octet-stream']['schema']['type'] == 'string'
+
+    pdf_resp = FileResponse('application/pdf')
+    pdf_spec = pdf_resp.generate_spec()
+    assert pdf_spec['200']['description'] == DEFAULT_CODE_DESC["HTTP_200"]
+    assert pdf_spec['404']['description'] == DEFAULT_CODE_DESC["HTTP_404"]
+
+    assert pdf_spec['200']['content']['application/pdf']['schema']['format'] == 'binary'
+    assert pdf_spec['200']['content']['application/pdf']['schema']['type'] == 'string'

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -7,6 +7,7 @@ from openapi_spec_validator import validate_v3_spec
 from pydantic import BaseModel, StrictFloat, Field
 
 from spectree import Response
+from spectree.response import FileResponse
 from spectree.spec import SpecTree
 from spectree.config import Config
 from spectree.plugins import FlaskPlugin
@@ -108,21 +109,26 @@ def create_app():
     def lone_post():
         pass
 
+    @app.route('/file')
+    @api.validate(resp=FileResponse())
+    def get_file():
+        pass
+
     return app
 
 
 def test_spec_bypass_mode():
     app = create_app()
     api.register(app)
-    assert get_paths(api.spec) == ['/foo', '/lone']
+    assert get_paths(api.spec) == ['/file', '/foo', '/lone']
 
     app = create_app()
     api_customize_backend.register(app)
-    assert get_paths(api.spec) == ['/foo', '/lone']
+    assert get_paths(api.spec) == ['/file', '/foo', '/lone']
 
     app = create_app()
     api_greedy.register(app)
-    assert get_paths(api_greedy.spec) == ['/bar', '/foo', '/lone']
+    assert get_paths(api_greedy.spec) == ['/bar', '/file', '/foo', '/lone']
 
     app = create_app()
     api_strict.register(app)


### PR DESCRIPTION
Currently, Spectree assumes that all responses are of type `application/json`.

This adds a new `FileResponse` class, that will create a very basic spec for `200` and `404` responses.  The content type of the response can be customised.

We should investigate creating an abstract class/protocol for Response to make it a bit easier to create custom response types as OpenAPI has a lot more than just JSON responses.