### PR TITLE
fix binary content type for file request schemas

### DIFF
--- a/spectree/types.py
+++ b/spectree/types.py
@@ -121,7 +121,9 @@ class Request:
         if self.content_type == "application/octet-stream":
             return {
                 "content": {
-                    self.content_type: {"schema": {"type": "str", "format": "binary"}}
+                    self.content_type: {
+                        "schema": {"type": "string", "format": "binary"}
+                    }
                 }
             }
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -73,5 +73,5 @@ def test_file_request_spec():
     file_request = Request(content_type="application/octet-stream")
     spec = file_request.generate_spec()
     assert spec["content"] == {
-        "application/octet-stream": {"schema": {"type": "str", "format": "binary"}}
+        "application/octet-stream": {"schema": {"type": "string", "format": "binary"}}
     }


### PR DESCRIPTION
Fix the schema for octet-stream content type spec generation.

Not sure why the spec validation didn't catch this, maybe it's not possible to.